### PR TITLE
Updated page to properly report spec-compliant gamepad API results

### DIFF
--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -1,5 +1,5 @@
-h1 
-  |  HTML5 Gamepad Tester   
+h1
+  |  HTML5 Gamepad Tester
   .icon.icon-gamepad
 p.subtitle Displays info about all gamepads connected to your computer
 p.hint Press any button on your gamepad(s) to make them show up
@@ -12,42 +12,45 @@ p.hint Press any button on your gamepad(s) to make them show up
 
   .gamepad ng-repeat="gamepad in gamepads.gamepads track by $index"
 
-    div ng-if="!gamepad"  
-      h2.inactive 
-        span.icon {{$index + 1}}  
+    div ng-if="!gamepad"
+      h2.inactive
+        span.icon {{$index + 1}}
         span n/a
 
     div ng-if="gamepad"
-      h2.active 
-        span.icon {{$index + 1}}  
+      h2.active
+        span.icon {{$index + 1}}
         span {{gamepad.id}}
 
       .info
         ul
           li.large
-            label TIMESTAMP 
+            label TIMESTAMP
             value {{gamepad.timestamp}}
           li
-            label INDEX 
+            label INDEX
             value {{gamepad.index}}
+          li.med
+            label MAPPING
+            value {{mappingString(gamepad.mapping)}}
 
       .axes
         ul
-          li ng-style="shaderStyle(axis)" ng-repeat="axis in gamepad.axes track by $index"
+          li ng-style="axisStyle(axis)" ng-repeat="axis in gamepad.axes track by $index"
             label AXIS {{$index}}
             value {{axis | number:6}}
 
       .buttons
         ul
-          li ng-style="shaderStyle(button)" ng-repeat="button in gamepad.buttons track by $index"
+          li ng-style="buttonStyle(button)" ng-repeat="button in gamepad.buttons track by $index"
             label B{{$index}}
-            value {{button}}
+            value {{buttonValue(button)}}
 
   .faq
     h2 FAQ
 
     .question Why isn't my gamepad showing up?
-    .answer 
+    .answer
       |The Gamepad API is still inconsistent across browsers and OSes. Some things to check:
       ul
         li Is the device plugged in / connected via bluetooth
@@ -56,7 +59,7 @@ p.hint Press any button on your gamepad(s) to make them show up
         li Restart your web browser
 
     .question What information is being displayed here?
-    .answer 
+    .answer
       |Multiple gamepads can be connected to a computer at once. This displays them all, and their current state.
       ul
         li Timestamp: the time of the latest update from the gamepad

--- a/source/javascripts/all.js.coffee
+++ b/source/javascripts/all.js.coffee
@@ -4,7 +4,7 @@ class Gamepads
   constructor: ->
 
   poll: ->
-    @gamepads = navigator.webkitGetGamepads?() || []
+    @gamepads = navigator.getGamepads?() || navigator.webkitGetGamepads?() || []
 
 
 
@@ -16,7 +16,14 @@ angular.module("gamepadApp", [])
 .controller 'MainCtrl', ['$scope', ($scope) ->
   $scope.gamepads = new Gamepads
 
-  $scope.shaderStyle = (n) -> opacity: Math.abs(n)+0.3
+  $scope.axisStyle = (n) -> opacity: Math.abs(n)+0.3
+  $scope.buttonStyle = (n) ->
+    opacity: Math.abs($scope.buttonValue(n))+0.3
+    border: if $scope.buttonPressed(n) then '1px solid #888' else '1px solid transparent'
+
+  $scope.buttonValue = (b) -> if typeof(b) == 'number' then b else b.value
+  $scope.buttonPressed = (b) -> if typeof(b) == 'number' then b > 0.1 else b.pressed
+  $scope.mappingString = (m) -> if m then m else '[none]'
 
   updateLoop = ->
     $scope.gamepads.poll()

--- a/source/stylesheets/all.css.sass
+++ b/source/stylesheets/all.css.sass
@@ -27,7 +27,7 @@ a
 
 .gamepad-app
 
-  
+
   .gamepad
     margin: 30px 0
     position: relative
@@ -56,10 +56,10 @@ a
     overflow: hidden
     white-space: nowrap
     text-overflow: ellipsis
-  
+
   .info, .axes, .buttons
     margin: 5px 0
-  
+
   .info, .buttons, .axes
     li
       display: inline-block
@@ -72,12 +72,15 @@ a
   .info li
     width: 50px
 
+    &.med
+      width: 100px
+
     &.large
       width: 200px
 
   .axes li
     width: 100px
-  
+
   .buttons li
     width: 30px
 
@@ -87,7 +90,7 @@ a
     h2
       color: #888
       font-size: 200%
-      
+
     .question
       margin: 10px 0
 


### PR DESCRIPTION
Chrome is [being updated](https://codereview.chromium.org/183313003/) to use the newest [Gamepad API spec](https://dvcs.w3.org/hg/gamepad/raw-file/default/gamepad.html), which is compatible with Firefox's implementation (Available in Firefox 28+). This patch allows the page to properly poll the new format while preserving backwards compatibility with the old one.

Other minor updates:
- Added a border to the button states to indicate when "button.pressed" is true/false
- Added field to display "gamepad.mapping" string. 

I would appreciate if you could deploy this to http://html5gamepad.com/ so that I have a reliable example site to point developers at when the new API lands. Thanks for putting this site together, by the way! It's been a godsend for testing Chrome!
